### PR TITLE
2주차 / cowboysj / 7

### DIFF
--- a/week2-BFS,DFS,Greedy/cowboysj/1012_cowboysj.py
+++ b/week2-BFS,DFS,Greedy/cowboysj/1012_cowboysj.py
@@ -1,0 +1,41 @@
+import sys
+
+# 이동 방향 
+dx = [-1, 1, 0, 0]
+dy = [0, 0, -1, 1]
+
+sys.setrecursionlimit(10000)
+
+def dfs(x, y, N, M, farm, visited):
+    visited[x][y] = True
+    for i in range(4):
+        nx, ny = x + dx[i], y + dy[i]
+        if 0 <= nx < N and 0 <= ny < M and not visited[nx][ny] and farm[nx][ny] == 1:
+            dfs(nx, ny, N, M, farm, visited)
+
+T = int(sys.stdin.readline())  
+
+for i in range(T):
+    # N : 가로 길이, M : 세로 길이, K : 배추 개수
+    M, N, K = map(int, sys.stdin.readline().split())
+    
+    visited = [[False] * M for i in range(N)]  
+    
+    # 배추밭 초기화 (0: 배추 없음, 1: 배추 있음)
+    farm = [[0] * M for i in range(N)]
+    for j in range(K):
+        x, y = map(int, sys.stdin.readline().split())
+        farm[y][x] = 1
+    
+    # 지렁이 개수 
+    worm_count = 0
+    
+    for i in range(N):
+        for j in range(M):
+            if farm[i][j] == 1 and not visited[i][j]:
+                dfs(i, j, N, M, farm, visited)
+                worm_count += 1 
+
+    print(worm_count)
+
+

--- a/week2-BFS,DFS,Greedy/cowboysj/1260_cowboysj.py
+++ b/week2-BFS,DFS,Greedy/cowboysj/1260_cowboysj.py
@@ -1,0 +1,43 @@
+import sys
+
+# N : 정점의 개수, M : 간선의 개수, V : 시작 정점
+N, M, V = map(int, sys.stdin.readline().split())
+
+# 인접 행렬 생성
+graph = [[0] * (N + 1) for _ in range(N + 1)]
+for _ in range(M):
+    a, b = map(int, sys.stdin.readline().split())
+    graph[a][b] = graph[b][a] = 1  
+
+# 방문 리스트 초기화
+visited_dfs = [0] * (N + 1)  # DFS 방문 리스트
+visited_bfs = [0] * (N + 1)  # BFS 방문 리스트
+
+# DFS (스택 사용)
+def dfs(V):
+    stack = [V]  # 스택 초기화
+    while stack:
+        node = stack.pop()  # 스택에서 마지막 노드 꺼내기
+        if not visited_dfs[node]:  
+            visited_dfs[node] = 1  # 방문 처리
+            print(node, end=' ')
+            # 방문 가능한 노드를 내림차순으로 스택에 추가 (작은 번호가 나중에 push되어 먼저 방문)
+            for i in range(N, 0, -1):
+                if graph[node][i] == 1 and not visited_dfs[i]:
+                    stack.append(i)
+
+# BFS (리스트를 활용한 큐)
+def bfs(V):
+    queue = [V]  # 큐 초기화
+    visited_bfs[V] = 1  # 방문 처리
+    while queue:
+        node = queue.pop(0)  # 리스트의 첫 번째 원소 제거 (FIFO)
+        print(node, end=' ')
+        for i in range(1, N + 1):  # 작은 정점부터 방문
+            if graph[node][i] == 1 and visited_bfs[i] == 0:
+                queue.append(i)
+                visited_bfs[i] = 1  # 방문 처리
+
+dfs(V)
+print()
+bfs(V)

--- a/week2-BFS,DFS,Greedy/cowboysj/1931_cowboysj.py
+++ b/week2-BFS,DFS,Greedy/cowboysj/1931_cowboysj.py
@@ -1,0 +1,21 @@
+import sys
+
+num_meetings = int(input())  # 회의 수
+
+last_end_time = 0
+max_meetings = 0  
+
+meetings = []
+
+for i in range(num_meetings):
+    start, end = map(int, sys.stdin.readline().rstrip().split())
+    meetings.append([start, end])
+
+meetings.sort(key=lambda x: (x[1], x[0])) 
+
+for start, end in meetings:
+    if last_end_time <= start:  
+        max_meetings += 1
+        last_end_time = end 
+
+print(max_meetings)

--- a/week2-BFS,DFS,Greedy/cowboysj/1946_cowboysj.py
+++ b/week2-BFS,DFS,Greedy/cowboysj/1946_cowboysj.py
@@ -1,0 +1,19 @@
+import sys
+input = sys.stdin.readline
+T = int(input())
+
+for i in range(T):
+    N = int(input())
+    total = []
+    for j in range(N):
+        a, b = map(int, input().split())
+        total.append((a, b))
+
+    total.sort(key=lambda x: x[0])
+    count = 1
+    check = total[0][1]
+    for i in range(1, N):
+        if total[i][1] < check:
+            check = total[i][1]
+            count += 1
+    print(count)

--- a/week2-BFS,DFS,Greedy/cowboysj/2178_cowboysj.py
+++ b/week2-BFS,DFS,Greedy/cowboysj/2178_cowboysj.py
@@ -1,0 +1,22 @@
+import sys
+
+# 입력 받기
+N, M = map(int, sys.stdin.readline().split())
+maze = [list(map(int, list(sys.stdin.readline().strip()))) for _ in range(N)]
+
+# 이동 방향 
+dx = [-1, 1, 0, 0]
+dy = [0, 0, -1, 1]
+
+def bfs():
+    queue = [[0, 0]]  # (0,0)부터 시작
+    while queue:
+        x, y = queue.pop(0) 
+        for i in range(4):  
+            nx, ny = x + dx[i], y + dy[i]
+            if 0 <= nx < N and 0 <= ny < M and maze[nx][ny] == 1:  
+                maze[nx][ny] = maze[x][y] + 1  # 현재 위치 값 +1
+                queue.append([nx, ny])  # 이동한 좌표 추가
+    return maze[N-1][M-1]  # 도착점의 값 출력
+
+print(bfs())

--- a/week2-BFS,DFS,Greedy/cowboysj/2839_cowboysj.py
+++ b/week2-BFS,DFS,Greedy/cowboysj/2839_cowboysj.py
@@ -1,0 +1,19 @@
+import sys
+input = sys.stdin.readline
+
+N = int(input())  
+
+# 최대 5킬로그램 봉지를 사용하면서 나머지를 3킬로그램 봉지로 채워야됨
+#봉지 개수
+count = 0 
+
+while N >= 0:
+    if N % 5 == 0:  
+        count += N // 5  
+        print(count)
+        break
+    N -= 3  # 5킬로그램 봉지가 안되면 3킬로그램 봉지 하나를 뺌
+    count += 1  
+
+else:
+    print(-1)  

--- a/week2-BFS,DFS,Greedy/cowboysj/7569_cowboysj.py
+++ b/week2-BFS,DFS,Greedy/cowboysj/7569_cowboysj.py
@@ -1,0 +1,51 @@
+from collections import deque
+import sys
+
+# 6방향: 위, 아래, 왼쪽, 오른쪽, 앞, 뒤
+dx = [0, 0, 0, 0, 1, -1]
+dy = [1, -1, 0, 0, 0, 0]
+dz = [0, 0, 1, -1, 0, 0]
+
+def bfs(M, N, H, farm):
+    queue = deque()
+    
+    # 익은 토마토를 큐에 넣기
+    for z in range(H):
+        for y in range(N):
+            for x in range(M):
+                if farm[z][y][x] == 1:
+                    queue.append((x, y, z, 0))  # (x, y, z, 날짜)
+    
+    max_day = 0
+    
+    while queue:
+        x, y, z, day = queue.popleft()
+        
+        for i in range(6):
+            nx, ny, nz = x + dx[i], y + dy[i], z + dz[i]
+            if 0 <= nx < M and 0 <= ny < N and 0 <= nz < H and farm[nz][ny][nx] == 0:
+                farm[nz][ny][nx] = 1  # 익은 토마토로 변경
+                queue.append((nx, ny, nz, day + 1))  # 하루 증가
+                max_day = max(max_day, day + 1)
+    
+    # 모든 토마토가 익었는지 확인
+    for z in range(H):
+        for y in range(N):
+            for x in range(M):
+                if farm[z][y][x] == 0:  # 하나라도 익지 않은 토마토가 있으면 -1
+                    return -1
+    
+    return max_day
+
+M, N, H = map(int, sys.stdin.readline().split())
+
+farm = []
+
+for i in range(H):
+    layer = [list(map(int, sys.stdin.readline().split())) for i in range(N)]
+    farm.append(layer)
+
+result = bfs(M, N, H, farm)
+print(result)
+
+


### PR DESCRIPTION
## #️⃣ 2주차

### 🔗 2주차 문제
| **문제 번호** | **풀이 여부** |
|-------|----|
| 1260| ⭕️  |
| 2178| ⭕️|
| 1012| ⭕️|
| 7569|⭕️ |
| 1946| ⭕️ |
| 2839|⭕️ |
| 1931|⭕️  |

### 📍 어려웠던 점
#### 재귀 깊이 설정
배추 문제가 계속 안 돼서 찾아보니 파이썬의 기본 재귀 호출은 1000으로 설정되어 있기 때문에, 1000을 초과하면 `RecursionError`가 난다고 한다.
따라서 **`sys.setrecursionlimit(n)`** 설정을 해줘야 한다.

### 📝 NOTE
#### 1946 신입사원
1. 서류 성적으로 높은 순으로 정렬하고 서류 1등은 무조건 뽑음
2. 면접 성적 확인
- 면접 점수가 서류로 정렬했을 때 앞에 사람보다 등수가 낮은 사람이 있다면 탈락

#### 1931 회의실 배정 문제 전략
1. 일찍 끝나는 순으로 회의 정렬
2. 끝나는 시간이 같으면 빨리 시작하는 순서대로 정렬
→ 1,2번 한 번에 `meetings.sort(key=lambda x: (x[1], x[0])) `
4. 앞 회의가 끝나는 시간이 다음 회의가 시작되는 시간보다 작거나 같아야 함
